### PR TITLE
feat: add base alm controller to deployment script

### DIFF
--- a/script/SetupAll.s.sol
+++ b/script/SetupAll.s.sol
@@ -555,13 +555,15 @@ contract SetupAll is Script {
             cctp_  : domain.config.readAddress(".cctpTokenMessenger")
         });
 
-        domain.almController.grantRole(domain.almController.FREEZER(), domain.config.readAddress(".freezer"));
-        domain.almController.grantRole(domain.almController.RELAYER(), domain.safe);
+        domain.almController.grantRole(domain.almController.FREEZER(),            domain.config.readAddress(".freezer"));
+        domain.almController.grantRole(domain.almController.RELAYER(),            domain.safe);
         domain.almController.grantRole(domain.almController.DEFAULT_ADMIN_ROLE(), domain.l2BridgeInstance.govRelay);
+
         domain.almController.revokeRole(domain.almController.DEFAULT_ADMIN_ROLE(), msg.sender);
 
-        domain.almProxy.grantRole(domain.almProxy.CONTROLLER(), address(domain.almController));
+        domain.almProxy.grantRole(domain.almProxy.CONTROLLER(),         address(domain.almController));
         domain.almProxy.grantRole(domain.almProxy.DEFAULT_ADMIN_ROLE(), domain.l2BridgeInstance.govRelay);
+
         domain.almProxy.revokeRole(domain.almProxy.DEFAULT_ADMIN_ROLE(), msg.sender);
 
         vm.stopBroadcast();

--- a/script/SetupAll.s.sol
+++ b/script/SetupAll.s.sol
@@ -340,7 +340,7 @@ contract SetupAll is Script {
 
         vm.stopBroadcast();
 
-        ScriptTools.exportContract(mainnet.name, "safe",   mainnet.safe);
+        ScriptTools.exportContract(mainnet.name, "safe", mainnet.safe);
     }
 
     function setupALMController() internal {
@@ -403,7 +403,7 @@ contract SetupAll is Script {
         vm.selectFork(domain.forkId);
 
         // Pre-compute L2 deployment addresses
-        uint256 nonce      = vm.getNonce(deployer);
+        uint256 nonce = vm.getNonce(deployer);
 
         // Mainnet deploy
 
@@ -535,7 +535,7 @@ contract SetupAll is Script {
 
         vm.stopBroadcast();
 
-        ScriptTools.exportContract(domain.name, "safe",   domain.safe);
+        ScriptTools.exportContract(domain.name, "safe", domain.safe);
     }
 
     function setupOpStackALMController(OpStackForeignDomain storage domain) internal {

--- a/script/SetupAll.s.sol
+++ b/script/SetupAll.s.sol
@@ -231,6 +231,8 @@ contract SetupAll is Script {
 
         vm.broadcast();
         domain.spell    = new SetupMainnetSpell();
+
+        ScriptTools.exportContract(mainnet.name, "spell", address(domain.spell));
     }
 
     function createOpStackForeignDomain(string memory name) internal returns (OpStackForeignDomain memory domain) {
@@ -263,7 +265,6 @@ contract SetupAll is Script {
         ScriptTools.exportContract(mainnet.name, "nstImp",  mainnet.nstInstance.nstImp);
         ScriptTools.exportContract(mainnet.name, "nstJoin", mainnet.nstInstance.nstJoin);
         ScriptTools.exportContract(mainnet.name, "daiNst",  mainnet.nstInstance.daiNst);
-
         ScriptTools.exportContract(mainnet.name, "sNst",    mainnet.snstInstance.sNst);
         ScriptTools.exportContract(mainnet.name, "sNstImp", mainnet.snstInstance.sNstImp);
     }
@@ -471,12 +472,12 @@ contract SetupAll is Script {
 
         vm.stopBroadcast();
 
-        ScriptTools.exportContract(domain.name, "nst",        address(domain.nst));
-        ScriptTools.exportContract(domain.name, "sNst",       address(domain.snst));
-        ScriptTools.exportContract(domain.name, "l1GovRelay", domain.l1BridgeInstance.govRelay);
-        ScriptTools.exportContract(domain.name, "l1Escrow",   domain.l1BridgeInstance.escrow);
-        ScriptTools.exportContract(domain.name, "l1TokenBridge",   domain.l1BridgeInstance.bridge);
-        ScriptTools.exportContract(domain.name, "govRelay", domain.l2BridgeInstance.govRelay);
+        ScriptTools.exportContract(domain.name, "nst",           address(domain.nst));
+        ScriptTools.exportContract(domain.name, "sNst",          address(domain.snst));
+        ScriptTools.exportContract(domain.name, "l1GovRelay",    domain.l1BridgeInstance.govRelay);
+        ScriptTools.exportContract(domain.name, "l1Escrow",      domain.l1BridgeInstance.escrow);
+        ScriptTools.exportContract(domain.name, "l1TokenBridge", domain.l1BridgeInstance.bridge);
+        ScriptTools.exportContract(domain.name, "govRelay",      domain.l2BridgeInstance.govRelay);
         ScriptTools.exportContract(domain.name, "tokenBridge",   domain.l2BridgeInstance.bridge);
     }
 
@@ -497,8 +498,8 @@ contract SetupAll is Script {
         domain.dsrOracle.grantRole(domain.dsrOracle.DATA_PROVIDER_ROLE(), address(domain.dsrReceiver));
 
         ScriptTools.exportContract(domain.name, "l1DSRForwarder", domain.dsrForwarder);
-        ScriptTools.exportContract(domain.name, "dsrReceiver",  address(domain.dsrReceiver));
-        ScriptTools.exportContract(domain.name, "dsrOracle",    address(domain.dsrOracle));
+        ScriptTools.exportContract(domain.name, "dsrReceiver",    address(domain.dsrReceiver));
+        ScriptTools.exportContract(domain.name, "dsrOracle",      address(domain.dsrOracle));
     }
 
     function setupOpStackForeignPSM(OpStackForeignDomain storage domain) internal {

--- a/script/SetupAll.s.sol
+++ b/script/SetupAll.s.sol
@@ -37,6 +37,7 @@ import { AllocatorBuffer } from "lib/dss-allocator/src/AllocatorBuffer.sol";
 import { AllocatorVault }  from "lib/dss-allocator/src/AllocatorVault.sol";
 
 import { ALMProxy }          from "lib/spark-alm-controller/src/ALMProxy.sol";
+import { ForeignController } from "lib/spark-alm-controller/src/ForeignController.sol";
 import { MainnetController } from "lib/spark-alm-controller/src/MainnetController.sol";
 
 import { DSROracleForwarderBaseChain } from "lib/xchain-dsr-oracle/src/forwarders/DSROracleForwarderBaseChain.sol";
@@ -199,8 +200,9 @@ contract SetupAll is Script {
         L2TokenBridgeInstance l2BridgeInstance;
 
         // ALM Controller
-        address  almController;
-        ALMProxy almProxy;
+        address           safe;
+        ForeignController almController;
+        ALMProxy          almProxy;
 
         // PSM
         PSM3 psm;
@@ -341,22 +343,6 @@ contract SetupAll is Script {
         ScriptTools.exportContract(mainnet.name, "safe",   mainnet.safe);
     }
 
-    function setupOpStackSafe(OpStackForeignDomain storage domain) internal {
-        vm.selectFork(domain.forkId);
-
-        vm.startBroadcast();
-
-        domain.safe = _setupSafe(
-            domain.config.readAddress(".safeProxyFactory"),
-            domain.config.readAddress(".safeSingleton"),
-            domain.config.readAddress(".relayer")
-        );
-
-        vm.stopBroadcast();
-
-        ScriptTools.exportContract(domain.name, "safe",   domain.safe);
-    }
-
     function setupALMController() internal {
         vm.selectFork(mainnet.forkId);
 
@@ -370,6 +356,7 @@ contract SetupAll is Script {
             buffer_ : mainnet.allocatorIlkInstance.buffer,
             psm_    : mainnet.chainlog.getAddress("MCD_LITE_PSM_USDC_A"),
             daiNst_ : mainnet.nstInstance.daiNst,
+            cctp_   : mainnet.config.readAddress(".cctpTokenMessenger"),
             snst_   : mainnet.snstInstance.sNst
         });
 
@@ -524,7 +511,7 @@ contract SetupAll is Script {
         vm.startBroadcast();
 
         domain.psm = new PSM3(
-            base.config.readAddress(".usdc"),
+            domain.config.readAddress(".usdc"),
             address(domain.nst),
             address(domain.snst),
             address(domain.dsrOracle)
@@ -533,6 +520,54 @@ contract SetupAll is Script {
         vm.stopBroadcast();
 
         ScriptTools.exportContract(domain.name, "psm", address(domain.psm));
+    }
+
+    function setupOpStackSafe(OpStackForeignDomain storage domain) internal {
+        vm.selectFork(domain.forkId);
+
+        vm.startBroadcast();
+
+        domain.safe = _setupSafe(
+            domain.config.readAddress(".safeProxyFactory"),
+            domain.config.readAddress(".safeSingleton"),
+            domain.config.readAddress(".relayer")
+        );
+
+        vm.stopBroadcast();
+
+        ScriptTools.exportContract(domain.name, "safe",   domain.safe);
+    }
+
+    function setupOpStackALMController(OpStackForeignDomain storage domain) internal {
+        vm.selectFork(domain.forkId);
+
+        vm.startBroadcast();
+
+        // Temporarily granting admin role to the deployer for straightforward configuration
+        domain.almProxy = new ALMProxy(msg.sender);
+        domain.almController = new ForeignController({
+            admin_ : msg.sender,
+            proxy_ : address(domain.almProxy),
+            psm_   : address(domain.psm),
+            nst_   : address(domain.nst),
+            usdc_  : domain.config.readAddress(".usdc"),
+            snst_  : address(domain.snst),
+            cctp_  : domain.config.readAddress(".cctpTokenMessenger")
+        });
+
+        domain.almController.grantRole(domain.almController.FREEZER(), domain.config.readAddress(".freezer"));
+        domain.almController.grantRole(domain.almController.RELAYER(), domain.safe);
+        domain.almController.grantRole(domain.almController.DEFAULT_ADMIN_ROLE(), domain.l2BridgeInstance.govRelay);
+        domain.almController.revokeRole(domain.almController.DEFAULT_ADMIN_ROLE(), msg.sender);
+
+        domain.almProxy.grantRole(domain.almProxy.CONTROLLER(), address(domain.almController));
+        domain.almProxy.grantRole(domain.almProxy.DEFAULT_ADMIN_ROLE(), domain.l2BridgeInstance.govRelay);
+        domain.almProxy.revokeRole(domain.almProxy.DEFAULT_ADMIN_ROLE(), msg.sender);
+
+        vm.stopBroadcast();
+
+        ScriptTools.exportContract(domain.name, "almProxy",      address(domain.almProxy));
+        ScriptTools.exportContract(domain.name, "almController", address(domain.almController));
     }
 
     function run() public {
@@ -553,7 +588,7 @@ contract SetupAll is Script {
         setupOpStackCrossChainDSROracle(base);
         setupOpStackForeignPSM(base);
         setupOpStackSafe(base);
-
+        setupOpStackALMController(base);
     }
 
 }

--- a/script/SetupAll.s.sol
+++ b/script/SetupAll.s.sol
@@ -391,40 +391,6 @@ contract SetupAll is Script {
         ScriptTools.exportContract(mainnet.name, "almController", address(mainnet.almController));
     }
 
-    function setupOpStackALMController(OpStackForeignDomain storage domain) internal {
-        vm.selectFork(domain.forkId);
-
-        vm.startBroadcast();
-
-        domain.almProxy = new ALMProxy(Ethereum.SPARK_PROXY);
-        domain.almController = new MainnetController({
-            admin_  : Ethereum.SPARK_PROXY,
-            proxy_  : address(domain.almProxy),
-            vault_  : domain.allocatorIlkInstance.vault,
-            buffer_ : domain.allocatorIlkInstance.buffer,
-            psm_    : domain.chainlog.getAddress("MCD_LITE_PSM_USDC_A"),
-            daiNst_ : domain.nstInstance.daiNst,
-            snst_   : domain.snstInstance.sNst
-        });
-
-        DSPauseProxyAbstract(domain.admin).exec(address(domain.spell),
-            abi.encodeCall(domain.spell.initALMController, (
-                address(domain.spell),
-                domain.nstInstance,
-                domain.allocatorIlkInstance,
-                domain.almProxy,
-                domain.almController,
-                domain.config.readAddress(".freezer"),
-                domain.safe
-            ))
-        );
-
-        vm.stopBroadcast();
-
-        ScriptTools.exportContract(mainnet.name, "almProxy",      address(mainnet.almProxy));
-        ScriptTools.exportContract(mainnet.name, "almController", address(mainnet.almController));
-    }
-
     // Deploy an instance of NST which will closely resemble the L2 versions of the tokens
     // TODO: This should be replaced by the actual tokens when they are available
     function deployNstInstance(

--- a/script/input/1/base.json
+++ b/script/input/1/base.json
@@ -1,7 +1,9 @@
 {
   "usdc": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   "chainlogPrefix": "BASE",
+  "freezer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "relayer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
-  "safeSingleton": "0x41675C099F32341bf84BFc5382aF534df5C7461a"
+  "safeSingleton": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
+  "cctpTokenMessenger": "0x1682Ae6375C4E4A97e4B583BC394c861A46D8962"
 }

--- a/script/input/1/base.json
+++ b/script/input/1/base.json
@@ -1,4 +1,7 @@
 {
   "usdc": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  "chainlogPrefix": "BASE"
+  "chainlogPrefix": "BASE",
+  "relayer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+  "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
+  "safeSingleton": "0x41675C099F32341bf84BFc5382aF534df5C7461a"
 }

--- a/script/input/1/mainnet.json
+++ b/script/input/1/mainnet.json
@@ -7,5 +7,6 @@
   "relayer": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
   "freezer": "0x298b375f24CeDb45e936D7e21d6Eb05e344adFb5",
   "safeProxyFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
-  "safeSingleton": "0x41675C099F32341bf84BFc5382aF534df5C7461a"
+  "safeSingleton": "0x41675C099F32341bf84BFc5382aF534df5C7461a",
+  "cctpTokenMessenger": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155"
 }


### PR DESCRIPTION
Adding ALM Controller deployment to Base.

Quirks:
1. Simplified configuration without spell. I think it's ok like this for configuring test infra purposes.
2. There is no freezer set up on base, so I just assigned relayer wallet as the freezer. I can deploy a SAFE with the same owners as on mainnet, but I don't think we need freezer at all for testing.

Additionally
- A minor fix to the PSM3 deployment
- Some formatting tweaks